### PR TITLE
Refactor math gcd import usage

### DIFF
--- a/maxflow.py
+++ b/maxflow.py
@@ -1,5 +1,4 @@
-from collections import deque
-
+import collections
 
 class mf_graph:
     n = 0
@@ -83,7 +82,7 @@ class mf_graph:
         assert s != t
         level = [0 for i in range(self.n)]
         Iter = [0 for i in range(self.n)]
-        que = deque([])
+        que = collections.deque([])
 
         def bfs():
             for i in range(self.n):
@@ -136,7 +135,7 @@ class mf_graph:
 
     def min_cut(self, s):
         visited = [False for i in range(self.n)]
-        que = deque([s])
+        que = collections.deque([s])
         while que:
             p = que.popleft()
             visited[p] = True

--- a/maxflow.py
+++ b/maxflow.py
@@ -1,5 +1,6 @@
 import collections
 
+
 class mf_graph:
     n = 0
     g = []

--- a/prime_fact.py
+++ b/prime_fact.py
@@ -1,7 +1,6 @@
 import math
 import random
-from collections import Counter
-
+import collections.Counter
 
 def is_probable_prime(n):
     if n < 2:
@@ -54,7 +53,7 @@ def _solve(N):
 
 
 def prime_fact(N):
-    res = Counter()
+    res = collections.Counter()
     p = 2
     while p <= 10**4 and N > 1:
         if N % p == 0:

--- a/prime_fact.py
+++ b/prime_fact.py
@@ -2,6 +2,7 @@ import math
 import random
 import collections
 
+
 def is_probable_prime(n):
     if n < 2:
         return False

--- a/prime_fact.py
+++ b/prime_fact.py
@@ -1,6 +1,6 @@
 import math
 import random
-import collections.Counter
+import collections
 
 def is_probable_prime(n):
     if n < 2:

--- a/prime_fact.py
+++ b/prime_fact.py
@@ -1,4 +1,4 @@
-from math import gcd, isqrt
+import math
 import random
 from collections import Counter
 
@@ -13,7 +13,7 @@ def is_probable_prime(n):
         if n % p == 0:
             return False
 
-    r = isqrt(n)
+    r = math.isqrt(n)
     if r * r == n:
         return False
 
@@ -45,7 +45,7 @@ def _solve(N):
         y = (x * x + c) % N
         d = 1
         while d == 1:
-            d = gcd(x - y, N)
+            d = math.gcd(x - y, N)
             x = (x * x + c) % N
             y = (y * y + c) % N
             y = (y * y + c) % N
@@ -88,4 +88,4 @@ def totient(N):
 
 
 def lcm(x, y):
-    return (x * y) // gcd(x, y)
+    return (x * y) // math.gcd(x, y)

--- a/tests/test_prime_fact.py
+++ b/tests/test_prime_fact.py
@@ -194,11 +194,11 @@ class TestPrimeFact(unittest.TestCase):
                 self.assertEqual(n % d, 0)
 
         # Test lcm property: lcm(a,b) * gcd(a,b) = a * b
-        from math import gcd
+        import math
 
         test_pairs = [(12, 18), (15, 20), (7, 11)]
         for a, b in test_pairs:
-            self.assertEqual(prime_fact.lcm(a, b) * gcd(a, b), a * b)
+            self.assertEqual(prime_fact.lcm(a, b) * math.gcd(a, b), a * b)
 
     def test_consistency_checks(self):
         """Test consistency between different functions"""


### PR DESCRIPTION
## Summary
- avoid `from math import gcd` by importing `math` and using `math.gcd`
- update corresponding tests to use `math.gcd`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b058b8074483288aa7577f17cd6296