### PR TITLE
scc: speed up iterative DFS by dropping tuple-based stack simulation

### DIFF
--- a/scc.py
+++ b/scc.py
@@ -10,53 +10,55 @@ def scc(N, edges):
     for e in edges:
         elist[counter[e[0]]] = e[1]
         counter[e[0]] += 1
-    visited = []
+
     low = [0] * N
     Ord = [-1] * N
     ids = [0] * N
-    NG = [0, 0]
+    visited = []
+    now_ord = 0
+    group_num = 0
 
-    def dfs(v):
-        stack = [(v, -1, 0), (v, -1, 1)]
-        while stack:
-            v, bef, t = stack.pop()
-            if t:
-                if bef != -1 and Ord[v] != -1:
-                    low[bef] = min(low[bef], Ord[v])
-                    stack.pop()
-                    continue
-                low[v] = NG[0]
-                Ord[v] = NG[0]
-                NG[0] += 1
-                visited.append(v)
-                for i in range(start[v], start[v + 1]):
-                    to = elist[i]
-                    if Ord[to] == -1:
-                        stack.append((to, v, 0))
-                        stack.append((to, v, 1))
-                    else:
-                        low[v] = min(low[v], Ord[to])
+    for root in range(N):
+        if Ord[root] != -1:
+            continue
+        node_stack = [root]
+        it_stack = [start[root + 1] - 1]
+        low[root] = Ord[root] = now_ord
+        now_ord += 1
+        visited.append(root)
+        while node_stack:
+            v = node_stack[-1]
+            i = it_stack[-1]
+            if i >= start[v]:
+                it_stack[-1] = i - 1
+                to = elist[i]
+                if Ord[to] == -1:
+                    low[to] = Ord[to] = now_ord
+                    now_ord += 1
+                    visited.append(to)
+                    node_stack.append(to)
+                    it_stack.append(start[to + 1] - 1)
+                elif Ord[to] < low[v]:
+                    low[v] = Ord[to]
             else:
+                node_stack.pop()
+                it_stack.pop()
                 if low[v] == Ord[v]:
                     while True:
                         u = visited.pop()
                         Ord[u] = N
-                        ids[u] = NG[1]
+                        ids[u] = group_num
                         if u == v:
                             break
-                    NG[1] += 1
-                low[bef] = min(low[bef], low[v])
+                    group_num += 1
+                if node_stack:
+                    bef = node_stack[-1]
+                    if low[v] < low[bef]:
+                        low[bef] = low[v]
 
     for i in range(N):
-        if Ord[i] == -1:
-            dfs(i)
-    for i in range(N):
-        ids[i] = NG[1] - 1 - ids[i]
-    group_num = NG[1]
-    counts = [0] * group_num
-    for x in ids:
-        counts[x] += 1
-    groups = [[] for i in range(group_num)]
+        ids[i] = group_num - 1 - ids[i]
+    groups = [[] for _ in range(group_num)]
     for i in range(N):
         groups[ids[i]].append(i)
     return groups


### PR DESCRIPTION
## Summary
- The previous `scc()` simulated recursion by pushing `(v, bef, t)` tuples onto a stack — up to two tuple allocations per edge, plus duplicate pushes when multiple frontier nodes shared an undiscovered neighbor (detected and discarded later at pop time).
- Replaced it with the standard "one frame per active vertex + resumable edge-iterator index" iterative DFS, so each vertex is pushed at most once and each edge is scanned exactly once. Also flattened the nested `dfs()` closure into the main function body to avoid `LOAD_DEREF` overhead on `low`/`Ord`/`visited`.
- Output is byte-for-byte identical to the previous implementation (verified below) — no behavior change, no API change.

## Why
Reported that stuffing tuples onto the stack looked like the bottleneck in `scc()`; profiling/benchmarking confirmed it.

## Test plan
- [x] `python3 -m unittest discover -s tests` — all 146 existing tests pass (including `two_sat.py`, which depends on `scc`)
- [x] Randomized differential test: 3500+ random graphs (up to 60 vertices/200 edges, and smaller dense graphs) comparing old vs. new implementation output — 0 mismatches
- [x] Benchmarked old vs. new on larger graphs:
  - random n=200000, m=200000: 2.24x faster
  - random n=100000, m=400000: 1.29x faster
  - random n=50000, m=500000: 1.87x faster
  - chain n=200000: 1.38x faster
  - big single cycle n=300000: 2.31x faster
  - fan-in heavy DAG n=4000, m=100000: 1.21x faster
- [x] Repo's existing `benchmarks/workloads.py` already includes an `scc` workload for the perf-comparison CI


---
_Generated by [Claude Code](https://claude.ai/code/session_01ETGHArtGpZYVHQfLSwnLhe)_